### PR TITLE
remove `null` phone numbers on details

### DIFF
--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -6,7 +6,7 @@
 export default {
     props: ['resource', 'resourceName', 'resourceId', 'field'],
     beforeMount() {
-        if (this.field.linkOnDetail) {
+        if (this.field.linkOnDetail && this.field.value) {
             this.field.asHtml = true;
             this.field.value = `<a href="tel:${this.field.value}" class="text-primary">${this.field.value}</a>`
         }


### PR DESCRIPTION
With nullable phone numbers (even maybe with empty numbers) its sometimes shows up as  

[null](#) (pointing to tel:null)

As its not the intended behavior, this extra check will make sure that only truthy phone numbers will show up.

_Edge case: it may also remove `tel:0` as a valid phone number._