### PR TITLE
Update type mixed

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -18,7 +18,7 @@ class PhoneNumber extends Field
 
     public $ignoreValidation = false;
 
-    public function __construct(string $name, ?string $attribute = null, ?mixed $resolveCallback = null)
+    public function __construct(string $name, ?string $attribute = null, mixed $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
     }


### PR DESCRIPTION
PHP 8 causes the following error which is resolved with this PR:

`Type mixed cannot be marked as nullable since mixed already includes null`