### PR TITLE
Error when you want to use a custom rule in the rules method

### DIFF
--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -147,7 +147,7 @@ class PhoneNumber extends Field
      */
     public function rules($rules)
     {
-        $this->rules = is_string($rules) ? func_get_args() : $rules;
+        parent::rules($rules);
 
         return $this->setRules();
     }


### PR DESCRIPTION
There was an error when you want to use a custom rule in the rules method.

This PR fixes this issue.